### PR TITLE
Move on from readline onto raw reading from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # hexify
 Hexify everything via piping or cli, using node.js
+
 ## How does this work?
-This project uses the readline module to read from the cli or piping.
+This project reads raw from stdin, converts to a hex string and prints it to the terminal.
+
 ## Will this project be maintained?
-Probably no, but i am planning to make some changes ~~(backwards compatible)~~ *couldn't find a way to make it backwards compatible, so it will be 2.0.0*
+It won't. I might revisit this project in the future.

--- a/index.js
+++ b/index.js
@@ -1,25 +1,10 @@
-'use strict'
-const readline = require('readline');
-const rl = readline.createInterface({
-  input: process.stdin,
-  output: process.stdout,
-  terminal: false
-});
-const arg = process.argv[2];
+'use strict';
+const process = require('node:process');
 
-if (arg == '--encode' || arg == '-e') {
-  rl.on('line', function(line){
-      process.stdout.write(Buffer.from(line, 'utf-8').toString('hex'));
-      process.stdout.write('\n');
-  });
-} else if (arg == '--decode' || arg == '-d') {
-    rl.on('line', function(line){
-      process.stdout.write(Buffer.from(line, 'hex').toString());
-      process.stdout.write('\n');
-  });
-} else {
-  rl.on('line', function(line){
-    process.stdout.write(Buffer.from(line, 'utf-8').toString('hex'));
-    process.stdout.write('\n');
-  });
-}
+process.stdin.on('data', async (chunk) => {
+	process.stderr.write(`${chunk.toString('hex')}`);
+});
+
+process.stdin.on('close', async () => {
+	process.stderr.write('\n');
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexify",
-  "version": "2.1.0-1",
+  "version": "2.1.0",
   "description": "Hexify everything via piping or cli, using node.js ",
   "main": "index.js",
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "hexify",
-  "version": "2.0.0",
+  "version": "2.1.0-1",
   "description": "Hexify everything via piping or cli, using node.js ",
   "main": "index.js",
   "keywords": [],
-  "author": "pass the burrito down#4261",
+  "author": "airime",
   "license": "EUPL-1.2-or-later"
 }


### PR DESCRIPTION
Readline outputs strings, while javascript strings aren't made to hold binary data, this causes corruption, which isn't really wanted here.